### PR TITLE
Mark Itopia Client as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This app relies on an outdated runtime that was marked as EOL years ago. There has been no development activity for 6 years. Even the provider website lists this app.